### PR TITLE
fix(ExceptionReporterExtension): do not allow exceptions to be thown outside of ExceptionReporter #2

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    
+
 env:
   packageVersionPrefix: ${{ '0.0.' }}
   packageVersionSuffixForFeatureBranch: ${{ '-alpha' }}
@@ -13,12 +13,15 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # os: [ macos-latest, ubuntu-latest, windows-latest  ]
+        os: [ windows-latest ]
+    runs-on: ${{ matrix.os }}
     name: Build and test
-
     steps:
       - uses: actions/checkout@v2
-          
+
       - name: Setup environment variables (main branch)
         if: github.ref == 'refs/heads/main'
         run: echo "packageVersion=${{ env.packageVersionPrefix }}${{ github.run_number }}${{ env.packageVersionSuffixForMainBranch }}" >> $GITHUB_ENV
@@ -54,7 +57,7 @@ jobs:
       - name: Test NuGet package
         run: ./smoketest.sh
         working-directory: RemoteControlledProcess.Nupkg.Tests
-        
+
       - name: Generate coverage reports
         run: reportgenerator "-reports:RemoteControlledProcess.Acceptance.Tests/TestResults/*.xml;RemoteControlledProcess.Unit.Tests/TestResults/*.xml" \
           "-targetdir:report" \
@@ -78,9 +81,9 @@ jobs:
   publish-reports:
     runs-on: ubuntu-latest
     name: Publish coverage reports
-    
+
     needs: build-and-test
-    
+
     steps:
       # the repository is required by codeclimate-action
       - uses: actions/checkout@v2
@@ -90,7 +93,7 @@ jobs:
         with:
           name: coverage-reports
           path: coverage-reports
-          
+
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@master
         with:
@@ -107,7 +110,7 @@ jobs:
   publish-nuget:
     runs-on: ubuntu-latest
     name: Publish NuGet package
-    
+
     needs: publish-reports
 
     steps:
@@ -116,7 +119,7 @@ jobs:
         with:
           name: nuget-package
           path: nuget-package
-          
+
       - name: Identify package version
         run: cat nuget-package/VERSION.txt >> $GITHUB_ENV
 


### PR DESCRIPTION
This branch re-creates the error condition reported by @alex-held and tries to fix it.

See https://github.com/wonderbird/RemoteControlledProcess/issues/9
See https://github.com/alex-held/RemoteControlledProcess/pull/2