### PR TITLE
refactor: use LoggerMessage instead of Logger extension methods

### DIFF
--- a/RemoteControlledProcess.Application/LogApplicationInfoService.cs
+++ b/RemoteControlledProcess.Application/LogApplicationInfoService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace katarabbitmq.client.app
+namespace RemoteControlledProcess.Application
 {
     public class LogApplicationInfoService : BackgroundService
     {
@@ -18,13 +18,7 @@ namespace katarabbitmq.client.app
             LogEnvironmentVariable("CONFIGURED_ENVIRONMENT_VARIABLE_2");
 
             var processId = Environment.ProcessId;
-            // TODO: Re-enable Inspection CA1848 "Use the LoggerMessage delegates"
-            // TODO: Re-enable Inspection CA2254 "Template should be a static expression"
-#pragma warning disable CA1848
-#pragma warning disable CA2254
-            _logger.LogInformation($"Process ID {processId}");
-#pragma warning restore CA2254
-#pragma warning restore CA1848
+            _logger.ProcessId(processId);
 
             return Task.CompletedTask;
         }
@@ -32,13 +26,7 @@ namespace katarabbitmq.client.app
         private void LogEnvironmentVariable(string name)
         {
             var value = Environment.GetEnvironmentVariable(name);
-            // TODO: Re-enable Inspection CA1848 "Use the LoggerMessage delegates"
-            // TODO: Re-enable Inspection CA2254 "Template should be a static expression"
-#pragma warning disable CA1848
-#pragma warning disable CA2254
-            _logger.LogInformation($"Configured environment variable 1: \"{value}\"");
-#pragma warning restore CA2254
-#pragma warning restore CA1848
+            _logger.ConfiguredEnvironmentVariable(value);
         }
     }
 }

--- a/RemoteControlledProcess.Application/LoggerExtensions.cs
+++ b/RemoteControlledProcess.Application/LoggerExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace RemoteControlledProcess.Application;
+
+internal static class LoggerExtensions
+{
+    private static readonly Action<ILogger, Exception> OperationCancelledAction;
+    private static readonly Action<ILogger, Exception> WaitingForCancellationRequestAction;
+    private static readonly Action<ILogger, Exception> StopRequestReceivedAction;
+    private static readonly Action<ILogger, Exception> ShuttingDownAction;
+    private static readonly Action<ILogger, Exception> ShutDownCompleteAction;
+    private static readonly Action<ILogger, int, Exception> ProcessIdAction;
+    private static readonly Action<ILogger, string, Exception> ConfiguredEnvironmentVariableAction;
+
+    static LoggerExtensions()
+    {
+        OperationCancelledAction = LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(OperationCancelled)), "Operation has been canceled");
+        WaitingForCancellationRequestAction = LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(WaitingForCancellationRequest)), "Waiting for cancellation request");
+        StopRequestReceivedAction = LoggerMessage.Define(LogLevel.Information, new EventId(3, nameof(StopRequestReceived)), "STOP request received");
+        ShuttingDownAction = LoggerMessage.Define(LogLevel.Information, new EventId(4, nameof(ShuttingDown)), "Shutting down ...");
+        ShutDownCompleteAction = LoggerMessage.Define(LogLevel.Debug, new EventId(5, nameof(ShutDownComplete)), "Shutdown complete");
+        ProcessIdAction = LoggerMessage.Define<int>(LogLevel.Information, new EventId(6, nameof(ProcessId)), "Process ID {ProcessId}");
+        ConfiguredEnvironmentVariableAction = LoggerMessage.Define<string>(LogLevel.Information, new EventId(7, nameof(ConfiguredEnvironmentVariable)), "Configured environment variable: \"{Value}\"");
+    }
+
+    public static void OperationCancelled(this ILogger logger) => OperationCancelledAction(logger, null);
+
+    public static void WaitingForCancellationRequest(this ILogger logger) => WaitingForCancellationRequestAction(logger, null);
+
+    public static void StopRequestReceived(this ILogger logger) => StopRequestReceivedAction(logger, null);
+
+    public static void ShuttingDown(this ILogger logger) => ShuttingDownAction(logger, null);
+
+    public static void ShutDownComplete(this ILogger logger) => ShutDownCompleteAction(logger, null);
+
+    public static void ProcessId(this ILogger logger, int processId) => ProcessIdAction(logger, processId, null);
+
+    public static void ConfiguredEnvironmentVariable(this ILogger logger, string value) => ConfiguredEnvironmentVariableAction(logger, value, null);
+}

--- a/RemoteControlledProcess.Application/Program.cs
+++ b/RemoteControlledProcess.Application/Program.cs
@@ -1,8 +1,7 @@
 using System;
 using Microsoft.Extensions.Hosting;
-using RemoteControlledProcess;
 
-namespace katarabbitmq.client.app
+namespace RemoteControlledProcess.Application
 {
     public static class Program
     {

--- a/RemoteControlledProcess.Application/RemoteControlledProcess.Application.csproj
+++ b/RemoteControlledProcess.Application/RemoteControlledProcess.Application.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <RootNamespace>katarabbitmq.client.app</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/RemoteControlledProcess.Application/SimpleHostBuilder.cs
+++ b/RemoteControlledProcess.Application/SimpleHostBuilder.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace katarabbitmq.client.app
+namespace RemoteControlledProcess.Application
 {
     public static class SimpleHostBuilder
     {

--- a/RemoteControlledProcess.Application/SimpleService.cs
+++ b/RemoteControlledProcess.Application/SimpleService.cs
@@ -3,9 +3,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using RemoteControlledProcess;
 
-namespace katarabbitmq.client.app
+namespace RemoteControlledProcess.Application
 {
     public class SimpleService : BackgroundService
     {
@@ -29,10 +28,7 @@ namespace katarabbitmq.client.app
             catch (OperationCanceledException)
             {
                 // This exception is desired, when shutdown is requested. No action is necessary.
-                // TODO: Re-enable Inspection CA1848 "Use the LoggerMessage delegates"
-#pragma warning disable CA1848
-                Logger.LogInformation("Operation has been canceled");
-#pragma warning restore CA1848
+                Logger.OperationCancelled();
             }
             catch (Exception e)
             {
@@ -46,11 +42,8 @@ namespace katarabbitmq.client.app
 
         private void RegisterCancellationRequest(CancellationToken stoppingToken)
         {
-            // TODO: Re-enable Inspection CA1848 "Use the LoggerMessage delegates"
-#pragma warning disable CA1848
-            Logger.LogInformation("Waiting for cancellation request");
-            stoppingToken.Register(() => Logger.LogInformation("STOP request received"));
-#pragma warning restore CA1848
+            Logger.WaitingForCancellationRequest();
+            stoppingToken.Register(() => Logger.StopRequestReceived());
             stoppingToken.ThrowIfCancellationRequested();
         }
 
@@ -61,11 +54,8 @@ namespace katarabbitmq.client.app
 
         private void ShutdownService()
         {
-            // TODO: Re-enable Inspection CA1848 "Use the LoggerMessage delegates"
-#pragma warning disable CA1848
-            Logger.LogInformation("Shutting down ...");
-            Logger.LogDebug("Shutdown complete");
-#pragma warning restore CA1848
+            Logger.ShuttingDown();
+            Logger.ShutDownComplete();
         }
     }
 }

--- a/RemoteControlledProcess.Unit.Tests/RemoteControlledProcess.Unit.Tests.csproj
+++ b/RemoteControlledProcess.Unit.Tests/RemoteControlledProcess.Unit.Tests.csproj
@@ -11,6 +11,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="MELT" Version="0.8.0" />
+    <PackageReference Include="MELT.Xunit" Version="0.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/RemoteControlledProcess/ExceptionReporterExtension.cs
+++ b/RemoteControlledProcess/ExceptionReporterExtension.cs
@@ -7,6 +7,12 @@ namespace RemoteControlledProcess
 {
     public static class ExceptionReporterExtension
     {
+        private static readonly Action<ILogger, string, int?, Exception> LogUnhandledExceptionAction;
+
+        static ExceptionReporterExtension() =>
+            LogUnhandledExceptionAction =
+                LoggerMessage.Define<string, int?>(LogLevel.Critical, new EventId(1, nameof(Log)), "Unhandled exception in {FileName}:{@LineNumber}");
+
         public static void Write(this Exception exception, TextWriter writer)
         {
             var exceptionOrigin = GetExceptionOriginFromStackTrace();
@@ -17,11 +23,7 @@ namespace RemoteControlledProcess
         public static void Log(this Exception exception, ILogger logger)
         {
             var exceptionOrigin = GetExceptionOriginFromStackTrace();
-            // TODO: Re-enable Inspection CA1848 "Use the LoggerMessage delegates"
-#pragma warning disable CA1848
-            logger.LogCritical(exception, "Unhandled exception in {FileName}:{@LineNumber}", exceptionOrigin.FileName,
-                exceptionOrigin.LineNumber);
-#pragma warning restore CA1848
+            LogUnhandledExceptionAction(logger, exceptionOrigin.FileName, exceptionOrigin.LineNumber, exception);
         }
 
         private static ExceptionOrigin GetExceptionOriginFromStackTrace()


### PR DESCRIPTION
By using the LoggerMessage delegates the static analysis warning CA1848 is cured. This ensures that optimal logging performance is achieved.